### PR TITLE
Allow `terminate()` to get called on a web client connection without …

### DIFF
--- a/lib/src/client/transport/xhr_transport.dart
+++ b/lib/src/client/transport/xhr_transport.dart
@@ -160,8 +160,9 @@ class XhrClientConnection extends ClientConnection {
 
   @override
   Future<void> terminate() async {
-    for (XhrTransportStream request in _requests) {
-      request.terminate();
+    while (_requests.isNotEmpty) {
+      final XhrTransportStream request = _requests.first;
+      await request.terminate();
     }
   }
 


### PR DESCRIPTION
…throwing an exception